### PR TITLE
Fix: astring-jsx fragment 

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1,5 +1,5 @@
 const acorn = require('acorn')
-const generate = require('astring-jsx')
+const generate = require('./astring')
 const jsx = require('acorn-jsx')
 const classFields = require('acorn-class-fields')
 const { importAssertions } = require('acorn-import-assertions')

--- a/lib/astring.js
+++ b/lib/astring.js
@@ -1,0 +1,43 @@
+// Modified version of astring-jsx to handle
+// certain jsx elements that the upstream astring
+// doesn't handle yet
+// https://github.com/Qard/astring-jsx/issues/8
+
+const astringJSX = require('astring-jsx')
+var extend = require('xtend')
+
+const generator = Object.assign(
+  {
+    JSXFragment: function JSXFragment(node, state) {
+      var output = state.output
+      output.write('<>')
+      for (child of node.children) {
+        this[child.type](child, state)
+      }
+      output.write('</>')
+    },
+    JSXEmptyExpression: function JSXEmptyExpression(node, state) {
+      // do nothing
+    },
+    JSXText: function JSXText(node, state) {
+      var output = state.output
+      output.write(node.value)
+    },
+  },
+  astringJSX.generator
+)
+
+function astring(ast, options) {
+  return astringJSX(
+    ast,
+    extend(
+      {
+        generator: generator,
+      },
+      options
+    )
+  )
+}
+
+astring.generator = generator
+module.exports = astring

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -104,15 +104,21 @@ function constructIslandClient(name, importPath) {
   import { render, h } from 'preact';
   
 ${readFileSync(resolve(__dirname, './client/helpers.js'), 'utf8')}
+
+customElements.define("${islandName}", class Island${name} extends HTMLElement {
+  constructor(){
+    super();
+  }
+
+  async connectedCallback() {
+      const c = await import(${JSON.stringify(importPath)});
+      const props = JSON.parse(this.dataset.props  || '{}');
+      mergePropsWithDOM(this,props);
+      render(restoreTree(c.default, props), this, this)
+  }
+})
   
-  customElements.define("${islandName}", class Island${name} extends HTMLElement {
-    async connectedCallback() {
-        const c = await import(${JSON.stringify(importPath)});
-        const props = JSON.parse(this.dataset.props  || '{}');
-        mergePropsWithDOM(this,props);
-        render(restoreTree(c.default, props), this, this)
-    }
-  })`
+  `
 }
 
 /**
@@ -145,7 +151,7 @@ function constructIslandServer(ast, name, options = {}) {
     code = `
     export default function Island${name}(props) {
       return h(Fragment,{},
-        h("${islandName}",{ "data-props": JSON.stringify(props) },h(${name}, props)),
+        h("${islandName}",{ "data-props": JSON.stringify(props) }, h(${name},props)),
         h("script",{async:true, src:"${path.join(
           baseURL,
           scriptBaseName

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@barelyhuman/preact-island-plugins",
-      "version": "0.1.0",
+      "version": "0.1.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.10.0",
@@ -18,7 +18,8 @@
         "acorn-static-class-features": "^1.0.0",
         "astring": "^1.8.6",
         "astring-jsx": "^1.0.1",
-        "esbuild": "^0.18.11"
+        "esbuild": "^0.18.11",
+        "xtend": "^4.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.22.8",
@@ -2832,7 +2833,8 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
       }
@@ -4796,7 +4798,9 @@
       }
     },
     "xtend": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "acorn-static-class-features": "^1.0.0",
     "astring": "^1.8.6",
     "astring-jsx": "^1.0.1",
-    "esbuild": "^0.18.11"
+    "esbuild": "^0.18.11",
+    "xtend": "^4.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",

--- a/playground/Container.js
+++ b/playground/Container.js
@@ -1,0 +1,17 @@
+// @island
+
+import { signal } from '@preact/signals'
+import Counter from './Counter'
+import TextIsland from './TextIsland'
+
+const count = signal(0)
+
+export default function Container({ children }) {
+  return (
+    <>
+      <Counter value={count} inc={() => (count.value += 1)} />
+      <Counter value={count} inc={() => (count.value += 1)} />
+      <TextIsland />
+    </>
+  )
+}

--- a/playground/Counter.js
+++ b/playground/Counter.js
@@ -1,8 +1,4 @@
 // @island
-import { useState } from 'preact/hooks'
-
-export default function Counter() {
-  const [count, setCount] = useState(0)
-
-  return <button onClick={() => setCount(count + 1)}>{count}</button>
+export default function Counter({ value, inc }) {
+  return <button onClick={inc}>{value}</button>
 }

--- a/playground/TextIsland.js
+++ b/playground/TextIsland.js
@@ -1,0 +1,7 @@
+// @island
+import { useState } from 'preact/hooks'
+
+export default function TextIsland() {
+  const [message, setMessage] = useState('Some Text')
+  return <a href="/">{message}</a>
+}

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@preact/signals": "^1.2.0",
         "esbuild": "^0.18.11",
         "express": "^4.18.2",
         "preact": "^10.15.1",
@@ -821,6 +822,30 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.0.tgz",
+      "integrity": "sha512-hrPOJ6L4XI/6iFJ++JitYG7W22E0+oNDkWH9W1gCutcKYCJq5tvhKcnxkLShCuctNZkwUBpu4XeIiVr5wC4NnA==",
+      "dependencies": {
+        "@preact/signals-core": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
+      "integrity": "sha512-5iYoZBhELLIhUQceZI7sDTQWPb+xcVSn2qk8T/aNl/VMh+A4AiPX9YRSh4XO7fZ6pncrVxl1Iln82poVqYVbbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -2481,6 +2506,19 @@
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
       "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
       "dev": true
+    },
+    "@preact/signals": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.0.tgz",
+      "integrity": "sha512-hrPOJ6L4XI/6iFJ++JitYG7W22E0+oNDkWH9W1gCutcKYCJq5tvhKcnxkLShCuctNZkwUBpu4XeIiVr5wC4NnA==",
+      "requires": {
+        "@preact/signals-core": "^1.4.0"
+      }
+    },
+    "@preact/signals-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
+      "integrity": "sha512-5iYoZBhELLIhUQceZI7sDTQWPb+xcVSn2qk8T/aNl/VMh+A4AiPX9YRSh4XO7fZ6pncrVxl1Iln82poVqYVbbw=="
     },
     "@rollup/plugin-babel": {
       "version": "6.0.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@preact/signals": "^1.2.0",
     "esbuild": "^0.18.11",
     "express": "^4.18.2",
     "preact": "^10.15.1",
@@ -20,12 +21,12 @@
     "serve-static": "^1.15.0"
   },
   "devDependencies": {
-    "@rollup/plugin-typescript": "^11.1.2",
-    "rollup": "^3.26.2",
     "@babel/core": "^7.21.0",
+    "@babel/plugin-transform-react-jsx": "^7.21.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@babel/plugin-transform-react-jsx": "^7.21.0",
+    "@rollup/plugin-typescript": "^11.1.2",
+    "rollup": "^3.26.2",
     "tslib": "^2.6.0",
     "typescript": "^5.1.6"
   }

--- a/playground/server.js
+++ b/playground/server.js
@@ -1,15 +1,15 @@
 import express from 'express'
 import comToString from 'preact-render-to-string'
-import Counter from './Counter'
 import serveStatic from 'serve-static'
 import { join } from 'path'
+import Container from './Container'
 
 const app = express()
 
 app.use('/public', serveStatic(join(__dirname, './client')))
 
 app.get('/', (req, res) => {
-  return res.send(comToString(<Counter />))
+  return res.send(comToString(<Container />))
 })
 
 app.listen(3000, () => {


### PR DESCRIPTION
Extends `astring` to handle JSXText, JSXFragment, JSXEmptyExpression cases as viable JSX syntax. 

