### PR TITLE
Loading modifiers for the island top level comment

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -38,13 +38,13 @@ function generateIslandsWithSource(sourceCode, filepath, options) {
   }
   const baseURL = options.baseURL || '/'
 
-  const isIsland =
-    sourceCode.indexOf('//@island') > -1 ||
-    sourceCode.indexOf('// @island') > -1
+  const isIsland = hasTopLevelComment(sourceCode)
 
   if (!isIsland) {
     return result
   }
+
+  const { viewModifier } = parseTopLevelComment(sourceCode)
 
   let clientOutput
 
@@ -76,7 +76,9 @@ function generateIslandsWithSource(sourceCode, filepath, options) {
     )
   }
 
-  const clientCode = constructIslandClient(componentName, filepath)
+  const clientCode = constructIslandClient(componentName, filepath, {
+    viewMods: viewModifier,
+  })
   const serverCode = constructIslandServer(ast, componentName, {
     baseURL,
     atomic: options.atomic,
@@ -112,8 +114,9 @@ function getIslandName(name) {
   return `island${name.replace(/([A-Z])/g, '-$1').toLowerCase()}`
 }
 
-function constructIslandClient(name, importPath) {
+function constructIslandClient(name, importPath, { viewMods } = {}) {
   const islandName = getIslandName(name)
+
   return `
   import { render, h } from 'preact';
   
@@ -127,12 +130,36 @@ customElements.define("${islandName}", class Island${name} extends HTMLElement {
   async connectedCallback() {
       const c = await import(${JSON.stringify(importPath)});
       const props = JSON.parse(this.dataset.props  || '{}');
-      mergePropsWithDOM(this,props);
-      render(restoreTree(c.default, props), this, this)
+      this.baseProps = props
+      this.component = c
+
+      ${viewMods.lazy ? `this.renderOnView()` : `this.renderIsland()`}
   }
-})
-  
-  `
+
+  renderOnView(){
+    const options = {
+      root: null,
+      threshold: 0.5
+    };
+
+    const self = this;
+
+    const callback = function(entries, observer) {
+       entries.forEach((entry) => {
+        if(!entry.isIntersecting) return 
+        self.renderIsland()
+       });
+    }
+
+    let observer = new IntersectionObserver(callback, options);
+    observer.observe(this);
+  }
+
+  renderIsland(){
+    mergePropsWithDOM(this, this.baseProps);
+    render(restoreTree(this.component.default, this.baseProps), this, this)
+  }
+})`
 }
 
 /**
@@ -216,4 +243,64 @@ function constructIslandServer(ast, name, options = {}) {
   const serverAST = astFromCode(code)
   ast.body = ast.body.concat(serverAST.body)
   return codeFromAST(ast)
+}
+
+function hasTopLevelComment(sourceCode) {
+  return (
+    sourceCode.indexOf('//@island') > -1 ||
+    sourceCode.indexOf('// @island') > -1
+  )
+}
+
+function parseTopLevelComment(sourceCode) {
+  const exists =
+    sourceCode.indexOf('//@island') > -1 ||
+    sourceCode.indexOf('// @island') > -1
+
+  const result = {
+    isIsland: false,
+    viewModifier: {
+      lazy: false,
+    },
+  }
+
+  if (!exists) {
+    return result
+  }
+
+  let commentLine
+
+  for (let line of sourceCode.split('\n')) {
+    if (line.indexOf('//@island') === -1 && line.indexOf('// @island') === -1) {
+      continue
+    }
+
+    commentLine = line
+    break
+  }
+
+  if (!commentLine) {
+    return result
+  }
+
+  result.isIsland = true
+
+  const parts = commentLine
+    .split(' ')
+    .filter(Boolean)
+    .map(x => x.trim())
+
+  parts
+    .filter(x => ['lazy', 'load'].includes(x))
+    .forEach(modType => {
+      if (modType === 'lazy') {
+        result.viewModifier.lazy = true
+      }
+
+      if (modType === 'load') {
+        result.viewModifier.lazy = false
+      }
+    })
+
+  return result
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -133,13 +133,17 @@ customElements.define("${islandName}", class Island${name} extends HTMLElement {
       this.baseProps = props
       this.component = c
 
-      ${viewMods.lazy ? `this.renderOnView()` : `this.renderIsland()`}
+      ${
+        viewMods.lazy
+          ? `this.renderOnView({threshold:${viewMods.threshold}})`
+          : `this.renderIsland()`
+      }
   }
 
-  renderOnView(){
+  renderOnView({threshold} = {}){
     const options = {
       root: null,
-      threshold: 0.5
+      threshold,
     };
 
     const self = this;
@@ -290,17 +294,16 @@ function parseTopLevelComment(sourceCode) {
     .filter(Boolean)
     .map(x => x.trim())
 
-  parts
-    .filter(x => ['lazy', 'load'].includes(x))
-    .forEach(modType => {
-      if (modType === 'lazy') {
-        result.viewModifier.lazy = true
-      }
-
-      if (modType === 'load') {
-        result.viewModifier.lazy = false
-      }
-    })
+  parts.forEach(modType => {
+    const modParams = modType.split(':')
+    const [mod, param] = modParams
+    if (mod === 'lazy') {
+      result.viewModifier.lazy = true
+      result.viewModifier.threshold = param ? +param : 0.5
+    } else if (mod === 'load') {
+      result.viewModifier.lazy = false
+    }
+  })
 
   return result
 }

--- a/playground/Counter.js
+++ b/playground/Counter.js
@@ -1,4 +1,5 @@
-// @island
+// @island lazy
+
 export default function Counter({ value, inc }) {
   return <button onClick={inc}>{value}</button>
 }


### PR DESCRIPTION
ability to pass in modifiers from the top level comment
to enable different modes of when the client hydrates the given
island


eg:
```js
// @island lazy
// or 
// @island lazy:0.1
```
Where `lazy` makes the island hydrate itself when it's visible, while `0.1` defines the threshold of what percent of the component is to be visible before it does this

